### PR TITLE
Added support for LWF002 Hue White light bulb

### DIFF
--- a/app.json
+++ b/app.json
@@ -1276,7 +1276,8 @@
           "LWB014",
           "LWB004",
           "LWB006",
-          "LWB007"
+          "LWB007",
+          "LWF002"
         ],
         "deviceId": 256,
         "profileId": 49246,


### PR DESCRIPTION
Support for Hue White light bulb - Product ID LWF002, Device ID 256, Profile ID 49246