### PR TITLE
Fix Hue1744630P7

### DIFF
--- a/app.json
+++ b/app.json
@@ -136,8 +136,8 @@
       "zigbee": {
         "manufacturerName": "Philips",
         "productId": "1744630P7",
-        "deviceId": 256,
-        "profileId": 49246,
+        "deviceId": 257,
+        "profileId": 260,
         "learnmode": {
           "instruction": {
             "en": "Plug in or toggle the unit to start pairing.\n\nIf pairing does not automatically start you probably need to reset the unit with a remote or a philips hue bridge."

--- a/drivers/1744630P7/device.js
+++ b/drivers/1744630P7/device.js
@@ -1,7 +1,7 @@
 "use strict";
 
-const HueColor = require("../HueColor.js");
+const HueWhite = require("../HueWhite.js");
 
-class Hue1744630P7 extends HueColor {}
+class Hue1744630P7 extends HueWhite {}
 
 module.exports = Hue1744630P7;


### PR DESCRIPTION
Fixes Hue outdoor wall Fuzo lamp 1744630P7.
It is probable that the same issue exists for the other Fuzo devices as well, at least in regards to Color but have not verified this yet.