### PR TITLE
fix: remove light_mode as garnea was incorrectly displaying RBG wheel

### DIFF
--- a/drivers/LTD011/driver.compose.json
+++ b/drivers/LTD011/driver.compose.json
@@ -2,7 +2,7 @@
   "name": {
     "en": "Garnea Downlight"
   },
-  "$extends": ["light_white_ambiance"],
+  "$extends": ["light_white_temperature"],
   "energy": {
     "approximation": {
       "usageOn": 7,


### PR DESCRIPTION
The Garnea are a White Ambiance light, allowing for on/off, dim and color temp. 
After adding the light, the RGB color wheel displays with in the app, and throws and error when altered.
Remove the color mode removes the RGB wheel and associated flows. 
