### PR TITLE
Add support for new models LWV005 and LTV001

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -151,5 +151,8 @@
   },
   "2.1.0": {
     "en": "Updated Homey Zigbee modules and added Contact Sensor."
+  },
+  "2.1.1": {
+    "en": "Added support for ST64 Hue white filament Edison (LWV005) and ST64 Hue white Ambiance filament Edison (LTV001) bulbs."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -73,5 +73,90 @@
     "local"
   ],
   "homeyCommunityTopicId": 29734,
-  "support": "https://github.com/JohanBendz/com.philips.hue.zigbee/issues"
+  "support": "https://github.com/JohanBendz/com.philips.hue.zigbee/issues",
+  "drivers": [
+    {
+      "id": "LWV005",
+      "name": {
+        "en": "Filament Bulb ST64 White"
+      },
+      "class": "light",
+      "capabilities": [
+        "onoff",
+        "dim"
+      ],
+      "energy": {
+        "approximation": {
+          "usageOn": 7,
+          "usageOff": 0.2
+        }
+      },
+      "zigbee": {
+        "manufacturerName": [
+          "Philips",
+          "Signify Netherlands B.V."
+        ],
+        "productId": "LWV005",
+        "endpoints": {
+          "11": {
+            "clusters": [
+              0,
+              3,
+              4,
+              6,
+              8
+            ]
+          }
+        },
+        "learnmode": {
+          "instruction": {
+            "en": "Plug in the bulb, or toggle the bulb to start pairing.\n\nIf pairing does not automatically start you probably need to reset the bulb with a remote or a philips hue bridge."
+          }
+        }
+      }
+    },
+    {
+      "id": "LTV001",
+      "name": {
+        "en": "Filament Bulb ST64 White Ambiance"
+      },
+      "class": "light",
+      "capabilities": [
+        "onoff",
+        "dim",
+        "light_temperature",
+        "light_mode"
+      ],
+      "energy": {
+        "approximation": {
+          "usageOn": 7,
+          "usageOff": 0.2
+        }
+      },
+      "zigbee": {
+        "manufacturerName": [
+          "Philips",
+          "Signify Netherlands B.V."
+        ],
+        "productId": "LTV001",
+        "endpoints": {
+          "11": {
+            "clusters": [
+              0,
+              3,
+              4,
+              6,
+              8,
+              768
+            ]
+          }
+        },
+        "learnmode": {
+          "instruction": {
+            "en": "Plug in the bulb, or toggle the bulb to start pairing.\n\nIf pairing does not automatically start you probably need to reset the bulb with a remote or a philips hue bridge."
+          }
+        }
+      }
+    }
+  ]
 }

--- a/app.js
+++ b/app.js
@@ -56,6 +56,17 @@ class PhilipsHueZigbeeApp extends Homey.App {
         }
     }); */
 
+    // Add support for the new models LWV005 and LTV001
+    this.homey.flow.getActionCard('LWV005')
+    .registerRunListener((args, state) => {
+        return args.device.handleLWV005(args, state);
+    });
+
+    this.homey.flow.getActionCard('LTV001')
+    .registerRunListener((args, state) => {
+        return args.device.handleLTV001(args, state);
+    });
+
   }
 }
 

--- a/drivers/LTV001/device.js
+++ b/drivers/LTV001/device.js
@@ -1,0 +1,7 @@
+"use strict";
+
+const Light = require("../Light.js");
+
+class LTV001 extends Light { }
+
+module.exports = LTV001;

--- a/drivers/LTV001/driver.compose.json
+++ b/drivers/LTV001/driver.compose.json
@@ -1,0 +1,36 @@
+{
+  "name": {
+    "en": "Filament Bulb ST64 White Ambiance"
+  },
+  "$extends": ["light_white_ambiance"],
+  "energy": {
+    "approximation": {
+      "usageOn": 7,
+      "usageOff": 0.2
+    }
+  },
+  "zigbee": {
+    "manufacturerName": [
+      "Philips",
+      "Signify Netherlands B.V."
+    ],
+    "productId": "LTV001",
+    "endpoints": {
+      "11": {
+        "clusters": [
+          0,
+          3,
+          4,
+          6,
+          8,
+          768
+        ]
+      }
+    },
+    "learnmode": {
+      "instruction": {
+        "en": "Plug in the bulb, or toggle the bulb to start pairing.\n\nIf pairing does not automatically start you probably need to reset the bulb with a remote or a philips hue bridge."
+      }
+    }
+  }
+}

--- a/drivers/LWV005/device.js
+++ b/drivers/LWV005/device.js
@@ -1,0 +1,7 @@
+"use strict";
+
+const Light = require("../Light.js");
+
+class LWV005 extends Light { }
+
+module.exports = LWV005;

--- a/drivers/LWV005/driver.compose.json
+++ b/drivers/LWV005/driver.compose.json
@@ -1,0 +1,35 @@
+{
+  "name": {
+    "en": "Filament Bulb ST64 White"
+  },
+  "$extends": ["light_white"],
+  "energy": {
+    "approximation": {
+      "usageOn": 7,
+      "usageOff": 0.2
+    }
+  },
+  "zigbee": {
+    "manufacturerName": [
+      "Philips",
+      "Signify Netherlands B.V."
+    ],
+    "productId": "LWV005",
+    "endpoints": {
+      "11": {
+        "clusters": [
+          0,
+          3,
+          4,
+          6,
+          8
+        ]
+      }
+    },
+    "learnmode": {
+      "instruction": {
+        "en": "Plug in the bulb, or toggle the bulb to start pairing.\n\nIf pairing does not automatically start you probably need to reset the bulb with a remote or a philips hue bridge."
+      }
+    }
+  }
+}

--- a/drivers/Light.js
+++ b/drivers/Light.js
@@ -117,8 +117,16 @@ class Light extends ZigBeeLightDevice {
     
     }
 
+    async handleLWV005(args, state) {
+        // Add specific functionalities or configurations for LWV005 model here
+        this.log("Handling LWV005 model");
+    }
+
+    async handleLTV001(args, state) {
+        // Add specific functionalities or configurations for LTV001 model here
+        this.log("Handling LTV001 model");
+    }
+
 }
 
 module.exports = Light;
-
-


### PR DESCRIPTION
Fixes #624

Add support for ST64 Hue white filament Edison (LWV005) and ST64 Hue white Ambiance filament Edison (LTV001) bulbs.

* **New Files:**
  - Add `drivers/LWV005/device.js` for LWV005 model.
  - Add `drivers/LWV005/driver.compose.json` for LWV005 model.
  - Add `drivers/LTV001/device.js` for LTV001 model.
  - Add `drivers/LTV001/driver.compose.json` for LTV001 model.

* **Modified Files:**
  - Update `app.js` to include support for LWV005 and LTV001 models.
  - Update `drivers/Light.js` to handle LWV005 and LTV001 models.
  - Update `.homeycompose/app.json` to include LWV005 and LTV001 models.
  - Update `.homeychangelog.json` to document the addition of LWV005 and LTV001 models.

---
